### PR TITLE
Raw bzip2 decoding with skipping tarfile header

### DIFF
--- a/EPFImporter.py
+++ b/EPFImporter.py
@@ -40,6 +40,11 @@
 from __future__ import with_statement
 import EPFIngester
 import pymysql as MySQLdb
+try:
+    from psycopg2cffi import compat
+    compat.register()
+except ImportError:
+    pass
 import psycopg2
 import os
 import sys

--- a/EPFIngester.py
+++ b/EPFIngester.py
@@ -37,6 +37,11 @@
 
 import EPFParser
 import pymysql as MySQLdb
+try:
+    from psycopg2cffi import compat
+    compat.register()
+except ImportError:
+    pass
 import psycopg2
 import os
 import datetime

--- a/EPFIngester.py
+++ b/EPFIngester.py
@@ -469,6 +469,7 @@ class Ingester(object):
             conn.commit()
 
         conn.close()
+        LOGGER.info("Ingested %i records", self.lastRecordIngested)
 
 
     def _checkProgress(self, recordGap=5000, timeGap=datetime.timedelta(0, 120, 0)):

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -89,8 +89,8 @@ class Parser(object):
         self.fieldDelim = fieldDelim
 
         # TODO: we need async-files here to make tarfile async
-        self.bzFile = io.open(filePath, mode='rb', buffering=10240)
-        self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
+        self.bzFile = io.open(filePath, mode='rb', buffering=102400)
+        self.rawFile = io.BufferedReader(self.bzFile, buffer_size=102400)
         self.eFile = bz2.open(self.rawFile, 'rb')
         self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
 

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -98,7 +98,7 @@ class Parser(object):
         # An exact record count exists in the last row of the file, but that would involve extracting the entire tarfile
         # first - something we want to avoid. So, instead, we just guess based on the input file size. This is ONLY used
         # to determine the ingestion strategy, not for anything else.
-        self.recordsExpected = 499_999 if self.fileSize < 10_000_000 else 500_001
+        self.recordsExpected = 499999 if self.fileSize < 10000000 else 500001
 
         #Extract the column names
         line1 = self.nextRowString(ignoreComments=False)

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -89,7 +89,7 @@ class Parser(object):
         self.fieldDelim = fieldDelim
 
         # TODO: we need async-files here to make tarfile async
-        self.bzFile = io.open(filePath, mode='rb', buffering=102400)
+        self.bzFile = io.open(filePath, mode='rb', buffering=102400) # 100k is bzip's minimum block size
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=102400)
         self.eFile = bz2.open(self.rawFile, 'rb')
         self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
@@ -136,8 +136,8 @@ class Parser(object):
         self.rawFile = None
         self.bzFile = None
 
-        self.bzFile = io.open(filePath, mode='rb', buffering=10240)
-        self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
+        self.bzFile = io.open(filePath, mode='rb', buffering=102400) # 100k is bzip's minimum block size
+        self.rawFile = io.BufferedReader(self.bzFile, buffer_size=102400)
         self.eFile = bz2.open(self.rawFile, 'rb')
         self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
 

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -42,6 +42,7 @@ import logging
 
 LOGGER = logging.getLogger()
 
+TAR_HEADER_SIZE = 512  # exactly one filesystem block.
 
 class SubstringNotFoundException(Exception):
     """
@@ -91,7 +92,7 @@ class Parser(object):
         self.bzFile = io.open(filePath, mode='rb', buffering=10240)
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
         self.eFile = bz2.open(self.rawFile, 'rb')
-        self.eFile.read(512)  # skip tarfile header
+        self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
 
         self.fileSize = os.path.getsize(filePath)
 
@@ -138,7 +139,7 @@ class Parser(object):
         self.bzFile = io.open(filePath, mode='rb', buffering=10240)
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
         self.eFile = bz2.open(self.rawFile, 'rb')
-        self.eFile.read(512)  # skip tarfile header
+        self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
 
         for pk in self.primaryKey:
             self.primaryKeyIndexes.append(self.columnNames.index(pk))
@@ -183,8 +184,8 @@ class Parser(object):
 
         N.B. with tbz streams, "0" is actually at 512.
         """
-        if self.seekPos != 512:
-            self.seekPos = 512
+        if self.seekPos != TAR_HEADER_SIZE:
+            self.seekPos = TAR_HEADER_SIZE
         self.latestRecordNum = 0
         if (recordNum <= 0):
             return

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -39,7 +39,6 @@ import io
 import os
 import re
 import logging
-import tarfile
 
 LOGGER = logging.getLogger()
 
@@ -92,7 +91,7 @@ class Parser(object):
         self.bzFile = io.open(filePath, mode='rb', buffering=10240)
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
         self.eFile = bz2.open(self.rawFile, 'rb')
-        self.eFile.seek(512)  # skip tarfile header
+        self.eFile.read(512)  # skip tarfile header
 
         self.fileSize = os.path.getsize(filePath)
 
@@ -112,7 +111,7 @@ class Parser(object):
 
         #Grab the next 6 lines, which should include all the header comments
         firstRows=[]
-        for j in range(6):
+        for j in range(10):
             firstRows.append(self.nextRowString(ignoreComments=False))
             firstRows = [aRow for aRow in firstRows if aRow] #strip None rows (possible if the file is < 6 rows)
 
@@ -139,7 +138,7 @@ class Parser(object):
         self.bzFile = io.open(filePath, mode='rb', buffering=10240)
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=10240)
         self.eFile = bz2.open(self.rawFile, 'rb')
-        self.eFile.seek(1024)  # skip tarfile header
+        self.eFile.read(512)  # skip tarfile header
 
         for pk in self.primaryKey:
             self.primaryKeyIndexes.append(self.columnNames.index(pk))

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     install_requires=[
         'configparser==5.0.2',
         'PyMySQL==1.0.2',
-        'psycopg2==2.8.6',
+        'psycopg2cffi==2.9.0',
     ],
 )


### PR DESCRIPTION
The point of this PR is to stream-read bzip2 files (so they can be loaded from streams) without decoding the tarfile. Tar is a very simple format, so we just skip the tar header and read the rest of the file - there's only ever 1 file in the apple tarballs anyway. Reading it as a stream avoids any use of seek(), which drastically speeds up reading from cloud storage.