### PR TITLE
Do 1/3 fewer string copy operations in the critical section (and get 1/3 speed increase)

### DIFF
--- a/EPFIngester.py
+++ b/EPFIngester.py
@@ -474,12 +474,12 @@ class Ingester(object):
                 break
 
             escapedRecords = self._escapeRecords(records) #This will sanitize the records
-            stringList = ["(%s)" % (", ".join(aRecord)) for aRecord in escapedRecords]
+            stringList = [(", ".join(aRecord)) for aRecord in escapedRecords]
 
             if self.isMysql:
                 cur = conn.cursor()
 
-            colVals = ", ".join(stringList)
+            colVals = f"({'), ('.join(stringList)})"
             exStr = exStrTemplate % (commandString, ignoreString, tableName, colNamesStr, colVals)
 
             try:


### PR DESCRIPTION
By not making two unnecessary intermediate copies of every single string, this speeds up the import by about a factor of 2-3.

Locally, this is the difference between it downloading data at 1-2Mb/sec and 10Mb/sec