### PR TITLE
Feature/data 13869 async files

### DIFF
--- a/EPFIngester.py
+++ b/EPFIngester.py
@@ -225,7 +225,7 @@ class Ingester(object):
             try:
                 # XXX: we always update in place. because collection_price REFUSES to be union merged in Postgres
                 #      ... takes 3 hours to create the union table before failing. Update in place is always faster.
-                if True or self.parser.recordsExpected < 500000: #update table in place
+                if self.isPostgresql or self.parser.recordsExpected < 500000: #update table in place
                     self._populateTable(self.tableName,
                                     resumeNum=fromRecord,
                                     isIncremental=True,

--- a/EPFIngester.py
+++ b/EPFIngester.py
@@ -416,7 +416,7 @@ class Ingester(object):
         commandString = ("REPLACE" if (isIncremental and self.isMysql) else "INSERT")
         ignoreString = ("IGNORE" if (skipKeyViolators and not isIncremental and self.isMysql) else "")
         colNamesStr = "(%s)" % (", ".join(self.parser.columnNames))
-        exStrTemplate = f"""{commandString} {ignoreString} INTO {tableName} {colNamesStr} VALUES %s"""
+        exStrTemplate = f"""{commandString} {ignoreString} INTO {tableName} {colNamesStr} VALUES"""
 
         # Psycopg2 async helpers. (They don't need to be >here< here, but they're not used anywhere else)
 
@@ -506,8 +506,7 @@ class Ingester(object):
             if self.isMysql:
                 cur = conn.cursor()
 
-            colVals = f"({'), ('.join(stringList)})"
-            exStr = exStrTemplate % (colVals,)
+            exStr = f"{exStrTemplate} ({'), ('.join(stringList)})"
 
             try:
                 if self.isPostgresql:
@@ -533,9 +532,8 @@ class Ingester(object):
             recCheck = self._checkProgress()
             if recCheck:
                 LOGGER.info(
-                    "...at record %i (%f%%)...",
-                    recCheck,
-                    (self.parser.bzFile.tell() / self.parser.fileSize) * 100
+                    "...at record %i...",
+                    recCheck
                 )
 
         if self.isPostgresql:

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -74,7 +74,7 @@ class Parser(object):
     exportModeTag = "exportMode:"
     recordCountTag = "recordsWritten:"
 
-    lineQueue = collections.deque(maxlen=8192)
+    lineQueue = collections.deque(maxlen=4096)
 
     def __init__(self, filePath, typeMap={"CLOB":"LONGTEXT"}, recordDelim='\x02\n', fieldDelim='\x01'):
         self.dataTypeMap = typeMap
@@ -118,7 +118,7 @@ class Parser(object):
                         q.append(ln)
                         break
                     except:
-                        pass
+                        time.sleep(0)  # pass but favour other threads
 
                 if not ln or len(ln) == 0 or ln[0] == "\x00":  # end of file - skipping zero-fill at the end of tarfile
                     break
@@ -228,7 +228,7 @@ class Parser(object):
                     ln = self.lineQueue.popleft()
                     break
                 except:
-                    pass
+                    time.sleep(0)  # pass but favour other threads
 
             if (not ln or len(ln) == 0 or ln[0] == "\x00"): #end of file - skipping zero-fill at the end of tarfile
                 break

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -200,21 +200,20 @@ class Parser(object):
         isFirstLine = True
         while True:
             ln = self.eFile.readline()
-            if (not ln or len(ln) == 0 or ln[0] == "\x00"): #end of file - skipping zero-fill at the end of tarfile
+            if not ln or ln == b'' or ln[0] == 0: #end of file - skipping zero-fill at the end of tarfile
                 break
-            ln = str(ln, "utf-8")
-            if (isFirstLine and ignoreComments and (ln.startswith(self.commentChar) or ln.startswith("\x00"))): #comment
+            if chr(ln[0]) == self.commentChar and isFirstLine and ignoreComments: #comment
                 continue
             lst.append(ln)
             if isFirstLine:
                 isFirstLine = False
-            if (ln.find(self.recordDelim) != -1): #last textual line of this record
+            if ln.endswith(bytes(self.recordDelim, 'utf-8')): #last textual line of this record
                 break
         if (len(lst) == 0):
             return None
         else:
-            rowString = "".join(lst) #concatenate the lines into a single string, which is the full content of the row
-            return rowString
+            rowString = b''.join(lst) #concatenate the lines into a single string, which is the full content of the row
+            return str(rowString, 'utf-8')
 
 
     def advanceToNextRecord(self):

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -118,7 +118,7 @@ class Parser(object):
                         q.append(ln)
                         break
                     except:
-                        time.sleep(0)  # pass but favour other threads
+                        pass
 
                 if not ln or len(ln) == 0 or ln[0] == "\x00":  # end of file - skipping zero-fill at the end of tarfile
                     break

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -38,6 +38,7 @@ import bz2
 import datetime
 import io
 import os
+import queue
 import re
 import logging
 
@@ -71,6 +72,8 @@ class Parser(object):
     exportModeTag = "exportMode:"
     recordCountTag = "recordsWritten:"
 
+    lineQueue = queue.Queue(maxsize=20000)
+
     def __init__(self, filePath, typeMap={"CLOB":"LONGTEXT"}, recordDelim='\x02\n', fieldDelim='\x01'):
         self.dataTypeMap = typeMap
         self.numberTypes = ["INTEGER", "INT", "BIGINT", "TINYINT"]
@@ -89,7 +92,6 @@ class Parser(object):
         self.recordDelim = recordDelim
         self.fieldDelim = fieldDelim
 
-        # TODO: we need async-files here to make tarfile async
         self.bzFile = io.open(filePath, mode='rb', buffering=102400) # 100k is bzip's minimum block size
         self.rawFile = io.BufferedReader(self.bzFile, buffer_size=102400)
         self.eFile = bz2.open(self.rawFile, 'rb')

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -297,6 +297,11 @@ class Parser(object):
                     # we've seen at least one integer field in a file with square brackets around it. Remove.
                     # r'[^0-9.-]'
                     rec[j] = self.nonNumberMatch.sub('', rec[j])
+                    if rec[j] == '':
+                        # Have seen at least one instance of the text "<UnknownKeyException>" in a column.
+                        # lost cause - just skip the record entirely.
+                        LOGGER.warning("Skipping record %i because it is malformed", self.latestRecordNum)
+                        return self.nextRecord()
 
             return rec
         else:

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -129,19 +129,6 @@ class Parser(object):
             elif aRow.startswith(exStart):
                 self.exportMode = self.splitRow(aRow, requiredPrefix=exStart)[0]
 
-        # Close and reopen as we don't have seek for a streams - and don't need it.
-        # self.eFile.seek(0, os.SEEK_SET) #seek back to the beginning
-        self.eFile.close()
-        self.rawFile.close()
-        self.eFile = None
-        self.rawFile = None
-        self.bzFile = None
-
-        self.bzFile = io.open(filePath, mode='rb', buffering=102400*10) # 100k is bzip's minimum block size, but load more anyway
-        self.rawFile = io.BufferedReader(self.bzFile, buffer_size=102400)
-        self.eFile = bz2.open(self.rawFile, 'rb')
-        self.eFile.read(TAR_HEADER_SIZE)  # skip tarfile header
-
         for pk in self.primaryKey:
             self.primaryKeyIndexes.append(self.columnNames.index(pk))
 
@@ -188,11 +175,11 @@ class Parser(object):
 
         N.B. with tbz streams, "0" is actually at 512.
         """
+        if (recordNum <= 0):
+            return
         if self.seekPos != TAR_HEADER_SIZE:
             self.seekPos = TAR_HEADER_SIZE
         self.latestRecordNum = 0
-        if (recordNum <= 0):
-            return
         for j in range(recordNum):
             self.advanceToNextRecord()
 

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -228,7 +228,7 @@ class Parser(object):
                     ln = self.lineQueue.popleft()
                     break
                 except:
-                    time.sleep(0)  # pass but favour other threads
+                    pass
 
             if (not ln or len(ln) == 0 or ln[0] == "\x00"): #end of file - skipping zero-fill at the end of tarfile
                 break

--- a/EPFParser.py
+++ b/EPFParser.py
@@ -34,16 +34,11 @@
 # OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY OF CONTRACT, TORT
 # (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import bz2
-import collections
 import datetime
-import io
 import os
 import re
 import logging
 import subprocess
-import threading
-import time
 
 LOGGER = logging.getLogger()
 


### PR DESCRIPTION
A few last speed improvements and bug fixes.

1. always use update in place strategry for postgres. Runs out of temp space on collection_price otherwise, and tbqh, it's fast enough.
2. optimise use of multiple connections. Uses first free conn, rather than enforcing them to be sequential.
3. read the bzip2 in a separate thread from the string processing, communicating popen.
4. don't close and reopen the file. Turns out, we don't need to do that. So, hopefully take better advantage of sequential reading with gcsfuse.